### PR TITLE
fix(ci): harden README stats workflow and stop hourly README overwrite

### DIFF
--- a/.github/workflows/dynamic-injection.yaml
+++ b/.github/workflows/dynamic-injection.yaml
@@ -1,9 +1,6 @@
 name: Dynamic README injection
+# Schedule disabled: this job overwrote README.md from README.template.md and conflicted with the profile README + stats workflow.
 on:
-    schedule: # Run workflow automatically
-        # This will make it run every hour
-        - cron: "0 * * * *"
-        # Run workflow manually (without waiting for the cron to be called), through the Github Actions Workflow page directly
     workflow_dispatch:
 jobs:
     get-office-quotes:

--- a/.github/workflows/update-readme-stats.yml
+++ b/.github/workflows/update-readme-stats.yml
@@ -1,4 +1,6 @@
-# Refresh GitHub stats and Top Langs SVGs so README images loads reliably
+# Refresh GitHub stats and Top Langs SVGs from your stats API (self-hosted recommended).
+# Set repository variable README_STATS_BASE_URL (e.g. https://your-app.vercel.app) — no trailing slash.
+# See: https://github.com/anuraghazra/github-readme-stats
 name: Update README stats
 
 on:
@@ -6,17 +8,50 @@ on:
   schedule:
     - cron: "0 12 * * *" # daily at 12:00 UTC
 
+permissions:
+  contents: write
+
 jobs:
   update:
     runs-on: ubuntu-latest
+    env:
+      STATS_BASE_URL: ${{ vars.README_STATS_BASE_URL }}
     steps:
       - uses: actions/checkout@v4
 
       - name: Fetch GitHub stats SVGs
         run: |
+          set -euo pipefail
           mkdir -p assets/github-stats
-          curl -sL "https://github-readme-stats.vercel.app/api?username=hamicch&show_icons=true" -o assets/github-stats/stats.svg
-          curl -sL "https://github-readme-stats.vercel.app/api/top-langs/?username=hamicch" -o assets/github-stats/top-langs.svg
+
+          BASE_URL="${STATS_BASE_URL:-}"
+          if [ -z "$BASE_URL" ]; then
+            echo "::warning::README_STATS_BASE_URL is not set. Using the public instance (often unavailable or rate-limited). Set it under Settings → Secrets and variables → Actions → Variables."
+            BASE_URL="https://github-readme-stats.vercel.app"
+          fi
+          BASE_URL="${BASE_URL%/}"
+
+          fetch_svg() {
+            local url="$1" out="$2" attempt=1 max=4
+            while [ "$attempt" -le "$max" ]; do
+              echo "Fetching (attempt $attempt/$max): $url"
+              if curl -fsSL --max-time 90 "$url" -o "$out"; then
+                if head -c 4096 "$out" | grep -qE '<svg|<\?xml'; then
+                  return 0
+                fi
+                echo "Response is not valid SVG/XML, retrying..."
+              else
+                echo "curl failed, retrying..."
+              fi
+              attempt=$((attempt + 1))
+              sleep 15
+            done
+            echo "::error::Could not fetch valid SVG from $url"
+            exit 1
+          }
+
+          fetch_svg "$BASE_URL/api?username=hamicch&show_icons=true" assets/github-stats/stats.svg
+          fetch_svg "$BASE_URL/api/top-langs/?username=hamicch" assets/github-stats/top-langs.svg
 
       - name: Commit and push if changed
         run: |

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 Software Engineer who builds scalable interfaces, integrates AI into real products, and ships clean, user-focused experiences.
 
+<!-- Stats SVGs: refresh via Actions workflow "Update README stats". Set repo variable README_STATS_BASE_URL to your self-hosted https://github.com/anuraghazra/github-readme-stats deployment (no trailing slash). -->
 [![GitHub stats](./assets/github-stats/stats.svg)](https://github.com/hamicch) [![Top Langs](./assets/github-stats/top-langs.svg)](https://github.com/hamicch)
 
 ## What I use


### PR DESCRIPTION
- Use optional README_STATS_BASE_URL repo variable for self-hosted github-readme-stats
- Retry fetches and reject non-SVG responses so error pages are not committed
- Grant contents: write for Actions push
- Disable Dynamic README injection cron; keep manual dispatch only
- Document stats setup in README HTML comment